### PR TITLE
typings: change from SyntheticEvent to Event

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,11 +1,9 @@
-import { EventHandler, SyntheticEvent } from 'react';
-
 /**
  * A custom React Hook that provides a declarative useEventListener.
  */
-declare function useEventListener<T extends SyntheticEvent<any>>(
+declare function useEventListener<T extends Event>(
   eventName: string,
-  handler: EventHandler<T>,
+  handler: (event: T) => void,
   element?: HTMLElement
 ): void;
 


### PR DESCRIPTION
React is not involved with addEventListener, so the event handler will be passed a normal DOM Event rather than a SyntheticEvent.